### PR TITLE
61 aspire configuration

### DIFF
--- a/src/CodeBreaker.Blazor.Client/Configuration/RemoteServiceDiscovery.cs
+++ b/src/CodeBreaker.Blazor.Client/Configuration/RemoteServiceDiscovery.cs
@@ -1,0 +1,68 @@
+﻿using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+using System.Net.Http.Json;
+
+namespace CodeBreaker.Blazor.Client.Configuration;
+
+/// <summary>
+/// A configuration provider that retrieves the URL of the gateway service from the remote Blazor application.
+/// </summary>
+internal class RemoteServiceDiscovery(Uri baseAddress) : ConfigurationProvider
+{
+    /// <summary>
+    /// Loads the configuration by retrieving the URLs from the remote service discovery endpoint.
+    /// </summary>
+    public override async void Load()
+    {
+        using var httpClient = new HttpClient()
+        {
+            BaseAddress = baseAddress
+        };
+        var urls = await httpClient.GetFromJsonAsync<IDictionary<string, string>>("service-discovery");
+
+        if (urls is null)
+            return;
+
+        foreach (var (key, value) in urls)
+            Set($"services:{key}", value);
+    }
+}
+
+internal class RemoteServiceDiscoveryConfigurationSource(Uri baseAddress) : IConfigurationSource
+{
+    /// <summary>
+    /// Builds the configuration provider using the specified configuration builder.
+    /// </summary>
+    public IConfigurationProvider Build(IConfigurationBuilder builder) =>
+        new RemoteServiceDiscovery(baseAddress);
+}
+
+internal static class RemoteServiceDiscoveryConfigurationExtensions
+{
+    /// <summary>
+    /// Adds the remote service discovery configuration provider to the configuration builder with the specified base address.
+    /// </summary>
+    public static IConfigurationBuilder AddRemoteServiceDiscovery(this IConfigurationBuilder builder, Uri baseAddress)
+    {
+        builder.Add(new RemoteServiceDiscoveryConfigurationSource(baseAddress));
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds the remote service discovery configuration provider to the configuration builder with the base address from the specified host environment.
+    /// </summary>
+    public static IConfigurationBuilder AddRemoteServiceDiscovery(this IConfigurationBuilder builder, IWebAssemblyHostEnvironment hostEnvironment)
+    {
+        builder.Add(new RemoteServiceDiscoveryConfigurationSource(new(hostEnvironment.BaseAddress)));
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds the remote service discovery configuration provider to the configuration builder with the base address from the specified host builder.
+    /// </summary>
+    public static IConfigurationBuilder AddRemoteServiceDiscovery(this IConfigurationBuilder builder, WebAssemblyHostBuilder hostBuilder)
+    {
+        builder.Add(new RemoteServiceDiscoveryConfigurationSource(new(hostBuilder.HostEnvironment.BaseAddress)));
+        return builder;
+    }
+}
+

--- a/src/CodeBreaker.Blazor.Client/Program.cs
+++ b/src/CodeBreaker.Blazor.Client/Program.cs
@@ -1,5 +1,6 @@
 using BlazorApplicationInsights;
 using Codebreaker.GameAPIs.Client;
+using CodeBreaker.Blazor.Client.Configuration;
 using CodeBreaker.Blazor.Client.Contracts.Services;
 using CodeBreaker.Blazor.Client.Extensions;
 using CodeBreaker.Blazor.Client.Services;
@@ -7,6 +8,8 @@ using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using Microsoft.FluentUI.AspNetCore.Components;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
+
+builder.Configuration.AddRemoteServiceDiscovery(new Uri (builder.HostEnvironment.BaseAddress));
 
 builder.Services.AddFluentUIComponents();
 

--- a/src/CodeBreaker.Blazor.Client/Program.cs
+++ b/src/CodeBreaker.Blazor.Client/Program.cs
@@ -24,12 +24,12 @@ builder.Services.AddMsalAuthentication(options =>
 });
 
 builder.Services.AddHttpClient<IGamerNameSuggestionClient, GamerNameSuggestionClient>(configure =>
-    configure.BaseAddress = new Uri("https://gateway/users")
+    configure.BaseAddress = new Uri("https://gateway/users/")
 )
 .ConfigureRemoteServiceDiscovery();
 
 builder.Services.AddHttpClient<IGamesClient, GamesClient>(configure =>
-    configure.BaseAddress = new Uri("https://gateway/games")
+    configure.BaseAddress = new Uri("https://gateway/games/")
 )
 .ConfigureRemoteServiceDiscovery();
 //.AddHttpMessageHandler<>(); // TODO

--- a/src/CodeBreaker.Blazor.Client/Program.cs
+++ b/src/CodeBreaker.Blazor.Client/Program.cs
@@ -24,10 +24,14 @@ builder.Services.AddMsalAuthentication(options =>
 });
 
 builder.Services.AddHttpClient<IGamerNameSuggestionClient, GamerNameSuggestionClient>(configure =>
-    configure.BaseAddress = new Uri(builder.Configuration.GetRequired("UserApiBase")));
+    configure.BaseAddress = new Uri("https://gateway/users")
+)
+.ConfigureRemoteServiceDiscovery();
 
 builder.Services.AddHttpClient<IGamesClient, GamesClient>(configure =>
-    configure.BaseAddress = new Uri(builder.Configuration.GetRequired("GameApiBase")));
+    configure.BaseAddress = new Uri("https://gateway/games")
+)
+.ConfigureRemoteServiceDiscovery();
 //.AddHttpMessageHandler<>(); // TODO
 
 builder.Services.AddScoped<IMobileDetectorService, MobileDetectorService>();

--- a/src/CodeBreaker.Blazor.Client/Services/GamerNameSuggestionClient.cs
+++ b/src/CodeBreaker.Blazor.Client/Services/GamerNameSuggestionClient.cs
@@ -7,7 +7,7 @@ public class GamerNameSuggestionClient(HttpClient httpClient) : IGamerNameSugges
 {
     public async Task<GamerNameSuggestionsResult> GetGamerNameSuggestionsAsync(int count = 10, CancellationToken cancellationToken = default)
     {
-        var response = await httpClient.GetAsync($"/gamer-names/suggestions?count={count}", cancellationToken);
+        var response = await httpClient.GetAsync($"gamer-names/suggestions?count={count}", cancellationToken);
         response.EnsureSuccessStatusCode();
         return await response.Content.ReadFromJsonAsync<GamerNameSuggestionsResult>(cancellationToken) ?? new ([]);
     }

--- a/src/CodeBreaker.Blazor/Program.cs
+++ b/src/CodeBreaker.Blazor/Program.cs
@@ -1,7 +1,6 @@
 using CodeBreaker.Blazor.Client.Pages;
 using Codebreaker.GameAPIs.Client;
 using CodeBreaker.Blazor.Components;
-using CodeBreaker.Blazor.Client.Extensions;
 using CodeBreaker.Blazor.Client.Services;
 using CodeBreaker.Blazor.Client.Contracts.Services;
 using Microsoft.FluentUI.AspNetCore.Components;
@@ -57,5 +56,32 @@ app.MapRazorComponents<App>()
     .AddInteractiveServerRenderMode()
     .AddInteractiveWebAssemblyRenderMode()
     .AddAdditionalAssemblies(typeof(GamePage).Assembly);
+
+/// <summary>
+/// Reads the environment variables for services and returns a mapping of service names to URLs.
+/// </summary>
+app.MapGet("/service-discovery", () =>
+{
+    var serviceMapping = new Dictionary<string, string>();
+    var environmentVariables = Environment.GetEnvironmentVariables();
+
+    foreach (var key in environmentVariables.Keys)
+    {
+        var keyText = key.ToString()!;
+
+        // Check if the key is a service URL (e.g. services__gameapis__http)
+        if (keyText.StartsWith("services__"))
+        {
+            // Extract the service name from the key (e.g. gameapis
+            var serviceName = keyText.Split("__")[1];
+
+            // Add the service name and URL to the mapping if it doesn't already exist
+            if (!serviceMapping.ContainsKey(serviceName))
+                serviceMapping.Add(serviceName, environmentVariables[key]!.ToString()!);
+        }
+    }
+
+    return Results.Json(serviceMapping);
+});
 
 app.Run();


### PR DESCRIPTION
Introduced a custom solution for providing some sort of service discovery to the Blazor client application, by:
- Implementing an endpoint in _CodeBreaker.Blazor_ providing a mapping between service names and service urls
- Implementing a custom configuration provider in _CodeBreaker.Blazor.Client_ for consuming that service mapping
- Implementing an extension method for configuring the httpclients to use the service mapping