### PR TITLE
Changed header of game page

### DIFF
--- a/src/CodeBreaker.Blazor.Client/Pages/GamePage.razor
+++ b/src/CodeBreaker.Blazor.Client/Pages/GamePage.razor
@@ -4,10 +4,9 @@
 @using Codebreaker.GameAPIs.Client.Models
 
 <FluentCard>
-    <h2>@Loc["GamePage_Title"]</h2>
-
     @if (_gameStatus == GameMode.NotRunning)
     {
+        <h2>@Loc["GamePage_Title"]</h2>
         <FluentGrid Class="align-items-end">
             <FluentGridItem xs="12" md="6">
                 @if (_isNamePrefilled)
@@ -59,7 +58,7 @@
     {
         <div class="header flex">
             <div>
-                <h2 class="flex-1">@_game?.GameType</h2>
+                <h2 class="flex-1">@Loc["GamePage_Title"] @FormatGameTypeString(_game?.GameType)</h2>
                 <StopWatch Running="@(_gameStatus == GameMode.MoveSet || _gameStatus == GameMode.Started)" />
             </div>
             <div>

--- a/src/CodeBreaker.Blazor.Client/Pages/GamePage.razor.cs
+++ b/src/CodeBreaker.Blazor.Client/Pages/GamePage.razor.cs
@@ -217,6 +217,9 @@ public partial class GamePage : IDisposable
         StateHasChanged();
     }
 
+    private string? FormatGameTypeString(string? gameTypeString) =>
+        gameTypeString?.Replace("Game", null);
+
     public void Dispose()
     {
         _timer?.Dispose();


### PR DESCRIPTION
I consider removing "Game" from the string representation of the gametype as not very clean.
But this is a consequence of the fact that the game type is represented as a string in the gameclient library.